### PR TITLE
Fixed issues with events that have neither ratio nor amount

### DIFF
--- a/js/ariva.js
+++ b/js/ariva.js
@@ -207,6 +207,11 @@ function extractEvents(page, handelsplatz) {
 			continue;
 		}
 
+		// filter events with neither ratio nor amount
+		if ((hashmap.get("Verhältnis") == null || hashmap.get("Verhältnis").trim() == "") && (hashmap.get("Betrag") == null || hashmap.get("Betrag") == "")) {
+			continue;
+		}
+
 		var dc = new Packages.jsq.datastructes.Datacontainer();
 		// Teilweise unterscheiden sich die Termine nach Handelsplätzen
 		if (hashmap.get("Handelsplätze") != null && hashmap.get("Handelsplätze") != "") {


### PR DESCRIPTION
This fixes the issue reported in https://github.com/faiteanu/JavaStockQuotes/issues/3

Simply put, I added a check that ignores any event that holds neither ratio nor amount information.